### PR TITLE
Customer in PaymentRequest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <logback-version>1.0.13</logback-version>
     <major-version>4</major-version>
     <minor-version>7</minor-version>
-    <patch-version>0</patch-version>
+    <patch-version>1-RC1</patch-version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <logback-version>1.0.13</logback-version>
     <major-version>4</major-version>
     <minor-version>7</minor-version>
-    <patch-version>1-RC1</patch-version>
+    <patch-version>1</patch-version>
   </properties>
 
   <dependencies>

--- a/src/docs/devguide/hugo/site/content/release-notes.md
+++ b/src/docs/devguide/hugo/site/content/release-notes.md
@@ -1,5 +1,9 @@
 This page describes changes to the Billpay Service Interface implemented across different releases of the interface.
 
+## v4.7.1 
+Released 9 January 2019
+- Fix Customer field setters and getters in PaymentRequest
+
 ## v4.7.0
 
 Released 9 January 2019

--- a/src/main/java/io/electrum/billpay/model/PaymentRequest.java
+++ b/src/main/java/io/electrum/billpay/model/PaymentRequest.java
@@ -99,6 +99,25 @@ public class PaymentRequest extends Transaction {
       this.paymentMethods = paymentMethods;
    }
 
+   /**
+    * Customer detail
+    **/
+   public PaymentRequest customer(Customer customer) {
+      this.customer = customer;
+      return this;
+   }
+
+   @ApiModelProperty(value = "Customer detail")
+   @JsonProperty("customer")
+   @Valid
+   public Customer getCustomer() {
+      return customer;
+   }
+
+   public void setCustomer(Customer customer) {
+      this.customer = customer;
+   }
+
    @Override
    public String toString() {
       return new StringBuilder().append("PaymentRequest{")


### PR DESCRIPTION
The getters and setters for Customer in the PaymentRequest were omitted in the original release. 
This is a patch to rectify that. 