### PR TITLE
Revert OSSRH push on failure, not on success!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - run:
           name: Release failed! Revert OSSRH release steps that might have been taken.
           command: /electrum/bin/revertReleaseOssrh.sh
+          when: on_fail
       - run:
           name: Release failed! Revert any release steps that might have been taken
           command: /electrum/bin/revertReleaseJava.sh


### PR DESCRIPTION
When I updated Circle I forgot a line. It always tries to revert the release to the central repository (it should only revert on failure). The consequence is that the new version isn't on Maven Central. This commit just adds the missing line.

p.s. I'm not going to try and get the current version on central. The last successful update to central wass version 4.5.1 on 16 May 2018! The next version will be pushed out.